### PR TITLE
Unify description of Photo ID `administrative_number` attribute with the description in the ISO spec

### DIFF
--- a/data-schemas/ds005-photo-id-travel-document.json
+++ b/data-schemas/ds005-photo-id-travel-document.json
@@ -176,7 +176,7 @@
         },
         "administrative_number": {
           "title": "Administrative Number",
-          "description": "Administrative number associated with the person.",
+          "description": "A number assigned by the Photo ID holder issuer for audit control or other purposes.",
           "type": "string"
         },
         "resident_street": {


### PR DESCRIPTION
Changed description of Photo ID `administrative_number` attribute to match with the attribute's description in ISO/IEC 23220-4 Annex C Photo ID.