### PR TITLE
Fix: Add a common schema for Legal PID fields to be reused across other schemas such as EUCC

### DIFF
--- a/data-schemas/common/ds004-legal-person-identification-data.json
+++ b/data-schemas/common/ds004-legal-person-identification-data.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "EWC - Legal PID",
+    "description": "Schema for Legal PID -  EWC WP3",
+    "type": "object",
+    "properties": {
+        "issuing_authority": {
+            "description": "Name of issuer from the MS that issued the ODI instance",
+            "type": "string"
+        },
+        "issuing_authority_id": {
+            "description": "ODI Id of the issuing authority. (Business register identifier for BRIS)",
+            "type": "string"
+        },
+        "issuing_country": {
+            "description": "Alpha-2 country code, as defined in ISO 3166-1, of the issuing country or territory.",
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 2
+        },
+        "issuing_jurisdiction": {
+            "description": "As defined in ISO 3166-2:2020, of the issuing country or territory.",
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 6
+        },
+        "issuance_date": {
+            "description": "Date and possibly time of issuance",
+            "type": "string",
+            "format": "date-time"
+        },
+        "expiry_date": {
+            "description": "Date and possibly time of ODI expiration",
+            "type": "string",
+            "format": "date-time"
+        },
+        "authentic_source_id": {
+            "description": "ODI Id of the issuing authority. (Business register identifier for BRIS)",
+            "type": "string"
+        },
+        "authentic_source_name": {
+            "description": "Name of issuer from the MS that issued the ODI instance",
+            "type": "string"
+        }
+    },
+    "required": [
+        "issuing_authority",
+        "issuing_authority_id",
+        "issuing_country",
+        "issuance_date",
+        "expiry_date",
+        "authentic_source_id",
+        "authentic_source_name"
+    ]
+}

--- a/data-schemas/ds004-legal-person-identification-data.json
+++ b/data-schemas/ds004-legal-person-identification-data.json
@@ -3,96 +3,103 @@
     "title": "EWC - Legal PID",
     "description": "Schema for Legal PID -  EWC WP3",
     "type": "object",
-    "properties": {
-        "issuing_authority": {
-            "description": "Name of issuer from the MS that issued the ODI instance",
-            "type": "string"
+    "allOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/EWC-consortium/eudi-wallet-rulebooks-and-schemas/refs/heads/main/data-schemas/common/ds004-legal-person-identification-data.json"
         },
-        "issuing_authority_id": {
-            "description": "ODI Id of the issuing authority. (Business register identifier for BRIS)",
-            "type": "string"
-        },
-        "issuing_country": {
-            "description": "Alpha-2 country code, as defined in ISO 3166-1, of the issuing country or territory.",
-            "type": "string",
-            "minLength": 2,
-            "maxLength": 2
-        },
-        "issuing_jurisdiction": {
-            "description": "As defined in ISO 3166-2:2020, of the issuing country or territory.",
-            "type": "string",
-            "minLength": 2,
-            "maxLength": 6
-        },
-        "issuance_date": {
-            "description": "Date and possibly time of issuance",
-            "type": "string",
-            "format": "datetime"
-        },
-        "expiry_date": {
-            "description": "Date and possibly time of ODI expiration",
-            "format": "datetime"
-        },
-        "authentic_source_id": {
-            "description": "ODI Id of the issuing authority. (Business register identifier for BRIS)",
-            "type": "string"
-        },
-        "authentic_source_name": {
-            "description": "Name of issuer from the MS that issued the ODI instance",
-            "type": "string"
-        },
-        "credentialSubject": {
-            "description": "Attributes representing a Legal PID",
-            "type": "object",
+        {
             "properties": {
-                "legal_person_id": {
-                    "description": "Unique id for organisation according to EUID",
+                "issuing_authority": {
+                    "description": "Name of issuer from the MS that issued the ODI instance",
                     "type": "string"
                 },
-                "legal_person_name": {
-                    "description": "Legal person name",
+                "issuing_authority_id": {
+                    "description": "ODI Id of the issuing authority. (Business register identifier for BRIS)",
                     "type": "string"
-                }
-            },
-            "required": [
-                "legal_person_id",
-                "legal_person_name"
-            ]
-        },
-        "credentialStatus": {
-            "description": "Defines suspension and/or revocation details for the issued credential. Further redefined by the type extension",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Exact identity for the credential status",
+                },
+                "issuing_country": {
+                    "description": "Alpha-2 country code, as defined in ISO 3166-1, of the issuing country or territory.",
                     "type": "string",
-                    "format": "uri"
+                    "minLength": 2,
+                    "maxLength": 2
                 },
-                "type": {
-                    "description": "Defines the revocation type extension",
+                "issuing_jurisdiction": {
+                    "description": "As defined in ISO 3166-2:2020, of the issuing country or territory.",
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 6
+                },
+                "issuance_date": {
+                    "description": "Date and possibly time of issuance",
+                    "type": "string",
+                    "format": "datetime"
+                },
+                "expiry_date": {
+                    "description": "Date and possibly time of ODI expiration",
+                    "format": "datetime"
+                },
+                "authentic_source_id": {
+                    "description": "ODI Id of the issuing authority. (Business register identifier for BRIS)",
                     "type": "string"
-                }
-            },
-            "required": [
-                "id",
-                "type"
-            ]
-        },
-        "credentialSchema": {
-            "description": "One or more schemas that validate the Verifiable Credential.",
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/credentialSchema"
                 },
-                {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/credentialSchema"
-                    }
+                "authentic_source_name": {
+                    "description": "Name of issuer from the MS that issued the ODI instance",
+                    "type": "string"
+                },
+                "credentialSubject": {
+                    "description": "Attributes representing a Legal PID",
+                    "type": "object",
+                    "properties": {
+                        "legal_person_id": {
+                            "description": "Unique id for organisation according to EUID",
+                            "type": "string"
+                        },
+                        "legal_person_name": {
+                            "description": "Legal person name",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "legal_person_id",
+                        "legal_person_name"
+                    ]
+                },
+                "credentialStatus": {
+                    "description": "Defines suspension and/or revocation details for the issued credential. Further redefined by the type extension",
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "description": "Exact identity for the credential status",
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "type": {
+                            "description": "Defines the revocation type extension",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "type"
+                    ]
+                },
+                "credentialSchema": {
+                    "description": "One or more schemas that validate the Verifiable Credential.",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/credentialSchema"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/credentialSchema"
+                            }
+                        }
+                    ]
                 }
-            ]
+            }
         }
-    },
+    ],
     "required": [
         "credentialSubject",
         "credentialStatus",


### PR DESCRIPTION
I have made the relevant changes to have a common schema for fields that can be reused across Legal PID and EUCC