### PR TITLE
feat: add support for validating image data URI in portrait claim

### DIFF
--- a/data-schemas/ds005-photo-id-travel-document.json
+++ b/data-schemas/ds005-photo-id-travel-document.json
@@ -45,9 +45,9 @@
         },
         "portrait": {
           "title": "Portrait",
-          "description": "A reproduction of the document holder’s portrait.",
+          "description": "A portrait image encoded as a Data URI.",
           "type": "string",
-          "format": "binary"
+          "pattern": "^data:image\\/(png|jpeg|gif|bmp|webp)(;base64)?,[a-zA-Z0-9+/=]*$"
         },
         "issue_date": {
           "title": "Issue Date",

--- a/data-schemas/ds005-photo-id-travel-document.json
+++ b/data-schemas/ds005-photo-id-travel-document.json
@@ -47,7 +47,7 @@
           "title": "Portrait",
           "description": "A portrait image encoded as a Data URI.",
           "type": "string",
-          "pattern": "^data:image\\/(png|jpeg|gif|bmp|webp)(;base64)?,[a-zA-Z0-9+/=]*$"
+          "pattern": "^data:image\\/(png|jpeg|gif|bmp|webp);base64url,[a-zA-Z0-9-_=]+$"
         },
         "issue_date": {
           "title": "Issue Date",


### PR DESCRIPTION
- Updated JSON schema to restrict the "portrait" claim to image Data URIs.
- Supported formats include PNG, JPEG, GIF, BMP, and WEBP.
- Ensures compliance with Base64 encoding and MIME type restrictions.