### PR TITLE
Photo ID portrait encoding from base64url-in-data-URI to base64-in-data-URI

### DIFF
--- a/data-schemas/ds005-photo-id-travel-document.json
+++ b/data-schemas/ds005-photo-id-travel-document.json
@@ -47,7 +47,7 @@
           "title": "Portrait",
           "description": "A portrait image encoded as a Data URI.",
           "type": "string",
-          "pattern": "^data:image\\/(png|jpeg|gif|bmp|webp);base64url,[a-zA-Z0-9-_=]+$"
+          "pattern": "^data:image\\/(png|jpeg|gif|bmp|webp);base64,[a-zA-Z0-9+/=]+$"
         },
         "issue_date": {
           "title": "Issue Date",

--- a/data-schemas/ds005-photo-id-travel-document.json
+++ b/data-schemas/ds005-photo-id-travel-document.json
@@ -47,7 +47,7 @@
           "title": "Portrait",
           "description": "A portrait image encoded as a Data URI.",
           "type": "string",
-          "pattern": "^data:image\\/(png|jpeg|gif|bmp|webp);base64,[a-zA-Z0-9+/=]+$"
+          "pattern": "^data:image\\/(png|jpeg);base64,[a-zA-Z0-9+/=]+$"
         },
         "issue_date": {
           "title": "Issue Date",


### PR DESCRIPTION
@mat-work, we realised that using base64url encoding in a data URI does not seem to be compliant with [RFC 2397](https://www.rfc-editor.org/rfc/rfc2397). RFC 2397 specifies base64 as the only known encoding scheme. Changed base64url in `pattern` of PhotoID's iso23220.portrait field to base64.